### PR TITLE
Reinit after stop

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -408,6 +408,8 @@ function stop()
         box.visible = false
         box.screen = nil
     end
+    init()
+    
     print "stop"
 end
 


### PR DESCRIPTION
Call init() always at the end of stop(). This fixes issue with the boxes not drawing anymore after the first stop.
